### PR TITLE
Fix learning materials links

### DIFF
--- a/luhack_site/templates/index.j2
+++ b/luhack_site/templates/index.j2
@@ -46,8 +46,7 @@
 
             <h3>News</h3>
             <ul>
-                <li><a href="" target="_blank">Threatpost</a></li>
-                <li><a href="" target="_blank">Deepdotweb</a></li>
+                <li><a href="https://threatpost.com/" target="_blank">Threatpost</a></li>
                 <li><a href="https://thehackernews.com/" target="_blank">The Hacker News</a></li>
             </ul>
             <h3>Youtube</h3>


### PR DESCRIPTION
The href property was empty on the Threatpost link so I added the correct URL. I've also removed the link to Deepdotweb as the site is currently down.

(recreated [this](https://github.com/luhack/luhack.github.io/pull/1) pull request)